### PR TITLE
Clean up vim.pack plugin config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@ nvim
 
 spell/
 
-# In your personal fork, you likely want to comment this, since it's recommended to track
-# nvim-pack-lock.json in version control - see :help vim.pack-lockfile
-# For the official `nvim-lua/kickstart.nvim` git repository, we leave it ignored to avoid unneeded
-# merge conflicts.
-nvim-pack-lock.json
+# lazy.nvim is no longer used; ignore its old lockfile if it is still present locally.
+lazy-lock.json
 
 .DS_Store

--- a/lua/custom/plugins/_utils.lua
+++ b/lua/custom/plugins/_utils.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.gh(repo) return 'https://github.com/' .. repo end
+
+return M
+
+-- vim: ts=2 sts=2 sw=2 et

--- a/lua/custom/plugins/auto-dark-mode.lua
+++ b/lua/custom/plugins/auto-dark-mode.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add { gh 'f-person/auto-dark-mode.nvim' }
 

--- a/lua/custom/plugins/bufferline.lua
+++ b/lua/custom/plugins/bufferline.lua
@@ -1,9 +1,6 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
-vim.pack.add {
-  gh 'akinsho/bufferline.nvim',
-  gh 'nvim-tree/nvim-web-devicons',
-}
+vim.pack.add { gh 'akinsho/bufferline.nvim' }
 
 require('bufferline').setup {
   options = {

--- a/lua/custom/plugins/fugitive.lua
+++ b/lua/custom/plugins/fugitive.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add {
   gh 'tpope/vim-fugitive',

--- a/lua/custom/plugins/grug-far.lua
+++ b/lua/custom/plugins/grug-far.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add { gh 'MagicDuck/grug-far.nvim' }
 

--- a/lua/custom/plugins/gx.lua
+++ b/lua/custom/plugins/gx.lua
@@ -1,14 +1,19 @@
-local function gh(repo) return 'https://github.com/' .. repo end
-
 vim.g.netrw_nogx = 1 -- disable netrw gx
 
-vim.pack.add {
-  gh 'nvim-lua/plenary.nvim',
-  gh 'chrishrb/gx.nvim',
-}
+local function open_target(target)
+  if target and target ~= '' then vim.ui.open(target) end
+end
 
-require('gx').setup()
+vim.keymap.set('n', 'gx', function() open_target(vim.fn.expand '<cfile>') end, { desc = 'Open link or file under cursor' })
 
-vim.keymap.set({ 'n', 'x' }, 'gx', '<cmd>Browse<cr>')
+vim.keymap.set('x', 'gx', function()
+  local saved_reg = vim.fn.getreg 'z'
+  local saved_regtype = vim.fn.getregtype 'z'
+
+  vim.cmd.normal { 'gv"zy', bang = true }
+  open_target(vim.fn.getreg 'z')
+
+  vim.fn.setreg('z', saved_reg, saved_regtype)
+end, { desc = 'Open selected link or file' })
 
 -- vim: ts=2 sts=2 sw=2 et

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -8,7 +8,7 @@ local modules = {}
 
 -- Iterate over all Lua files in the plugins directory and load them.
 for file_name, type in vim.fs.dir(plugins_dir, { follow = true }) do
-  if (type == 'file' or type == 'link') and file_name:match '%.lua$' and file_name ~= 'init.lua' then
+  if (type == 'file' or type == 'link') and file_name:match '^[^_].*%.lua$' and file_name ~= 'init.lua' then
     local module = file_name:gsub('%.lua$', '')
     table.insert(modules, module)
   end

--- a/lua/custom/plugins/neogit.lua
+++ b/lua/custom/plugins/neogit.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add {
   gh 'nvim-lua/plenary.nvim',

--- a/lua/custom/plugins/noice.lua
+++ b/lua/custom/plugins/noice.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add {
   gh 'MunifTanjim/nui.nvim',
@@ -8,14 +8,12 @@ vim.pack.add {
 
 require('noice').setup {
   lsp = {
-    -- override markdown rendering so that **cmp** and other plugins use **Treesitter**
+    -- Override markdown rendering so that Noice uses Treesitter.
     override = {
       ['vim.lsp.util.convert_input_to_markdown_lines'] = true,
       ['vim.lsp.util.stylize_markdown'] = true,
-      ['cmp.entry.get_documentation'] = true, -- requires hrsh7th/nvim-cmp
     },
   },
-  -- you can enable a preset for easier configuration
   presets = {
     bottom_search = true, -- use a classic bottom cmdline for search
     command_palette = true, -- position the cmdline and popupmenu together

--- a/lua/custom/plugins/substitute.lua
+++ b/lua/custom/plugins/substitute.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add { gh 'gbprod/substitute.nvim' }
 

--- a/lua/custom/plugins/surround.lua
+++ b/lua/custom/plugins/surround.lua
@@ -2,7 +2,7 @@
 --
 -- To enable nvim-surround instead, uncomment the block below:
 --
--- local function gh(repo) return 'https://github.com/' .. repo end
+-- local gh = require('custom.plugins._utils').gh
 --
 -- vim.pack.add { { src = gh 'kylechui/nvim-surround', version = vim.version.range '*' } }
 -- require('nvim-surround').setup()

--- a/lua/custom/plugins/treesitter-endwise.lua
+++ b/lua/custom/plugins/treesitter-endwise.lua
@@ -1,4 +1,4 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add { gh 'RRethy/nvim-treesitter-endwise' }
 

--- a/lua/custom/plugins/treesitter-jump.lua
+++ b/lua/custom/plugins/treesitter-jump.lua
@@ -1,7 +1,7 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
 vim.pack.add { gh 'dsully/treesitter-jump.nvim' }
 
-vim.keymap.set('n', '%', function() require('treesitter-jump').jump() end)
+vim.keymap.set('n', '%', function() require('treesitter-jump').jump() end, { desc = 'Jump with treesitter' })
 
 -- vim: ts=2 sts=2 sw=2 et

--- a/lua/custom/plugins/trouble.lua
+++ b/lua/custom/plugins/trouble.lua
@@ -1,10 +1,6 @@
-local function gh(repo) return 'https://github.com/' .. repo end
+local gh = require('custom.plugins._utils').gh
 
-vim.pack.add {
-  gh 'folke/todo-comments.nvim',
-  gh 'nvim-tree/nvim-web-devicons',
-  gh 'folke/trouble.nvim',
-}
+vim.pack.add { gh 'folke/trouble.nvim' }
 
 require('trouble').setup { focus = true }
 

--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -1,0 +1,180 @@
+{
+  "plugins": {
+    "LuaSnip": {
+      "rev": "642b0c595e11608b4c18219e93b88d7637af27bc",
+      "src": "https://github.com/L3MON4D3/LuaSnip",
+      "version": "2.0.0 - 3.0.0"
+    },
+    "auto-dark-mode.nvim": {
+      "rev": "54058b4fe414bd64bd2904a6f8a63f1f14e3d8df",
+      "src": "https://github.com/f-person/auto-dark-mode.nvim"
+    },
+    "blink.cmp": {
+      "rev": "78336bc89ee5365633bcf754d93df01678b5c08f",
+      "src": "https://github.com/saghen/blink.cmp",
+      "version": "1.0.0 - 2.0.0"
+    },
+    "bufferline.nvim": {
+      "rev": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3",
+      "src": "https://github.com/akinsho/bufferline.nvim"
+    },
+    "conform.nvim": {
+      "rev": "619363c30309d29ffa631e67c8183f2a72caa373",
+      "src": "https://github.com/stevearc/conform.nvim"
+    },
+    "diffview.nvim": {
+      "rev": "4516612fe98ff56ae0415a259ff6361a89419b0a",
+      "src": "https://github.com/sindrets/diffview.nvim"
+    },
+    "fidget.nvim": {
+      "rev": "6f793b2bcd2d35e201c09520f698bb763220908a",
+      "src": "https://github.com/j-hui/fidget.nvim"
+    },
+    "gitsigns.nvim": {
+      "rev": "2038c666bd9d8a0b7349a0b6ee00dc83104b9ecf",
+      "src": "https://github.com/lewis6991/gitsigns.nvim"
+    },
+    "grug-far.nvim": {
+      "rev": "c69859c1d5427ab5fc7ed12380ab521b4e336691",
+      "src": "https://github.com/MagicDuck/grug-far.nvim"
+    },
+    "guess-indent.nvim": {
+      "rev": "84a4987ff36798c2fc1169cbaff67960aed9776f",
+      "src": "https://github.com/NMAC427/guess-indent.nvim"
+    },
+    "indent-blankline.nvim": {
+      "rev": "d28a3f70721c79e3c5f6693057ae929f3d9c0a03",
+      "src": "https://github.com/lukas-reineke/indent-blankline.nvim"
+    },
+    "mason-lspconfig.nvim": {
+      "rev": "21c5b3ebeaa0412e28096bb0701434c51c1fbf76",
+      "src": "https://github.com/mason-org/mason-lspconfig.nvim"
+    },
+    "mason-nvim-dap.nvim": {
+      "rev": "9a10e096703966335bd5c46c8c875d5b0690dade",
+      "src": "https://github.com/jay-babu/mason-nvim-dap.nvim"
+    },
+    "mason-tool-installer.nvim": {
+      "rev": "443f1ef8b5e6bf47045cb2217b6f748a223cf7dc",
+      "src": "https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim"
+    },
+    "mason.nvim": {
+      "rev": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d",
+      "src": "https://github.com/mason-org/mason.nvim"
+    },
+    "mini.nvim": {
+      "rev": "c594be5b095204e99473825ec2dee872e7409a4d",
+      "src": "https://github.com/nvim-mini/mini.nvim"
+    },
+    "neo-tree.nvim": {
+      "rev": "83e7a2982fd12b9c3d35bc39dd5877cd91a02a61",
+      "src": "https://github.com/nvim-neo-tree/neo-tree.nvim",
+      "version": ">=0.0.0"
+    },
+    "neogit": {
+      "rev": "43ea1a0854052e583f647e0b35879f0158a70a78",
+      "src": "https://github.com/NeogitOrg/neogit"
+    },
+    "noice.nvim": {
+      "rev": "7bfd942445fb63089b59f97ca487d605e715f155",
+      "src": "https://github.com/folke/noice.nvim"
+    },
+    "nui.nvim": {
+      "rev": "de740991c12411b663994b2860f1a4fd0937c130",
+      "src": "https://github.com/MunifTanjim/nui.nvim"
+    },
+    "nvim-autopairs": {
+      "rev": "7b9923abad60b903ece7c52940e1321d39eccc79",
+      "src": "https://github.com/windwp/nvim-autopairs"
+    },
+    "nvim-dap": {
+      "rev": "9e848e09a697ee95302a3ef2dd43fd6eb709e570",
+      "src": "https://github.com/mfussenegger/nvim-dap"
+    },
+    "nvim-dap-go": {
+      "rev": "b4421153ead5d726603b02743ea40cf26a51ed5f",
+      "src": "https://github.com/leoluz/nvim-dap-go"
+    },
+    "nvim-dap-ui": {
+      "rev": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49",
+      "src": "https://github.com/rcarriga/nvim-dap-ui"
+    },
+    "nvim-lint": {
+      "rev": "01c9842c089069ab497430159312b2c8868a4590",
+      "src": "https://github.com/mfussenegger/nvim-lint"
+    },
+    "nvim-lspconfig": {
+      "rev": "bfcc0171a43f22afa61d927ffe9fcb6cb85dc99e",
+      "src": "https://github.com/neovim/nvim-lspconfig"
+    },
+    "nvim-nio": {
+      "rev": "21f5324bfac14e22ba26553caf69ec76ae8a7662",
+      "src": "https://github.com/nvim-neotest/nvim-nio"
+    },
+    "nvim-notify": {
+      "rev": "8701bece920b38ea289b457f902e2ad184131a5d",
+      "src": "https://github.com/rcarriga/nvim-notify"
+    },
+    "nvim-treesitter": {
+      "rev": "4916d6592ede8c07973490d9322f187e07dfefac",
+      "src": "https://github.com/nvim-treesitter/nvim-treesitter",
+      "version": "'main'"
+    },
+    "nvim-treesitter-endwise": {
+      "rev": "8fe8a95630f4f2c72a87ba1927af649e0bfaa244",
+      "src": "https://github.com/RRethy/nvim-treesitter-endwise"
+    },
+    "plenary.nvim": {
+      "rev": "74b06c6c75e4eeb3108ec01852001636d85a932b",
+      "src": "https://github.com/nvim-lua/plenary.nvim"
+    },
+    "substitute.nvim": {
+      "rev": "0d2077398552f069abccbd964a26dd7cd26882cd",
+      "src": "https://github.com/gbprod/substitute.nvim"
+    },
+    "telescope-fzf-native.nvim": {
+      "rev": "b25b749b9db64d375d782094e2b9dce53ad53a40",
+      "src": "https://github.com/nvim-telescope/telescope-fzf-native.nvim"
+    },
+    "telescope-ui-select.nvim": {
+      "rev": "6e51d7da30bd139a6950adf2a47fda6df9fa06d2",
+      "src": "https://github.com/nvim-telescope/telescope-ui-select.nvim"
+    },
+    "telescope.nvim": {
+      "rev": "427b576c16792edad01a92b89721d923c19ad60f",
+      "src": "https://github.com/nvim-telescope/telescope.nvim"
+    },
+    "todo-comments.nvim": {
+      "rev": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668",
+      "src": "https://github.com/folke/todo-comments.nvim"
+    },
+    "tokyonight.nvim": {
+      "rev": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6",
+      "src": "https://github.com/folke/tokyonight.nvim"
+    },
+    "treesitter-jump.nvim": {
+      "rev": "6727f5ed67923341ef53169255a84df2c5ee5de4",
+      "src": "https://github.com/dsully/treesitter-jump.nvim"
+    },
+    "trouble.nvim": {
+      "rev": "bd67efe408d4816e25e8491cc5ad4088e708a69a",
+      "src": "https://github.com/folke/trouble.nvim"
+    },
+    "vim-eunuch": {
+      "rev": "e86bb794a1c10a2edac130feb0ea590a00d03f1e",
+      "src": "https://github.com/tpope/vim-eunuch"
+    },
+    "vim-fugitive": {
+      "rev": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0",
+      "src": "https://github.com/tpope/vim-fugitive"
+    },
+    "vim-rhubarb": {
+      "rev": "5496d7c94581c4c9ad7430357449bb57fc59f501",
+      "src": "https://github.com/tpope/vim-rhubarb"
+    },
+    "which-key.nvim": {
+      "rev": "3aab2147e74890957785941f0c1ad87d0a44c15a",
+      "src": "https://github.com/folke/which-key.nvim"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- track `nvim-pack-lock.json` and ignore the old `lazy-lock.json`
- add a small custom plugin utility for GitHub plugin URLs
- remove stale custom dependencies on `gx.nvim` and `nvim-web-devicons`
- replace the gx plugin with a `vim.ui.open` mapping
- remove the stale nvim-cmp documentation override from Noice

## Validation
- `find lua -name '*.lua' -print0 | xargs -0 -n1 luac -p`\n- headless Neovim startup in an isolated XDG config/data dir\n\n_This was AI generated._